### PR TITLE
Support config-driven-helper version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-## 0.1.0 (unreleased)
+## 0.2.0 (30th August 2018)
+
+  * Support config-driven-helper version 3
+
+## 0.1.0 (10th August 2016)
 
   * Initial release

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'fratcliffe@inviqa.com'
 license 'apache2'
 description 'Installs/Configures certbot-cdh'
 long_description 'Installs/Configures certbot-cdh'
-version '0.1.0'
+version '0.2.0'
 
 issues_url 'https://github.com/inviqa/chef-certbot-cdh/issues'
 source_url 'https://github.com/inviqa/chef-certbot-cdh'
 
-depends 'config-driven-helper', '~> 2.5'
+depends 'config-driven-helper', '>= 2.5.0'
 depends 'certbot', '~> 0.1.0'


### PR DESCRIPTION
Relax constraint on config-driven-helper to allow 3.x